### PR TITLE
Fix issue where the incorrect version of the library

### DIFF
--- a/.mm_awesome_header.pl
+++ b/.mm_awesome_header.pl
@@ -47,9 +47,6 @@ push @defines, 'AES128CTR_IS_AVAILABLE' if has_aes128ctr();
 my %xsbuild = Alien::Base::Wrapper->new('Alien::Sodium')->mm_args2(
     "DEFINE" => join(" ", map { "-D$_" } @defines),
 );
-$xsbuild{"LIBS"}    = [ $alien_libs ];
-$xsbuild{"CCFLAGS"} = $alien_cflags;
-$xsbuild{"INC"}     = $alien_include;
 
 # use Data::Dumper;
 # print Dumper(\%xsbuild);

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -55,9 +55,6 @@ push @defines, 'AES128CTR_IS_AVAILABLE' if has_aes128ctr();
 my %xsbuild = Alien::Base::Wrapper->new('Alien::Sodium')->mm_args2(
     "DEFINE" => join(" ", map { "-D$_" } @defines),
 );
-$xsbuild{"LIBS"}    = [ $alien_libs ];
-$xsbuild{"CCFLAGS"} = $alien_cflags;
-$xsbuild{"INC"}     = $alien_include;
 
 # use Data::Dumper;
 # print Dumper(\%xsbuild);

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,28 +6,47 @@ use warnings;
 
 use ExtUtils::MakeMaker;
 
+use File::Spec::Functions qw(catdir); 
+
 use Alien::Sodium ();
 use Alien::Base::Wrapper ();
 use Devel::CheckLib qw(check_lib);
 
+my $alien_include = '-I' . catdir(Alien::Sodium->dist_dir(), 'include');
+my $alien_libs    = Alien::Sodium->libs();
+my $alien_cflags = Alien::Sodium->cflags();
+
+sub clean_ccflags {
+    use Config;
+    my $ccflags = $Config{ccflags};
+    $ccflags =~ s:-I\S*::g;
+    return $ccflags;
+}
+
 sub has_aes256gcm {
-    return check_lib(
+    use Mock::Config ccflags => clean_ccflags();
+    my $ret = check_lib(
         debug => 0,
         function => 'return !(!sodium_init() && crypto_aead_aes256gcm_is_available());',
-        LIBS => Alien::Sodium->libs,
-        ccflags => Alien::Sodium->cflags(),
+        LIBS => $alien_libs,
+        ccflags => $alien_cflags,
         header => 'sodium.h',
     );
+    Mock::Config->unimport;      # Undo overrides
+    return $ret;
 }
 
 sub has_aes128ctr {
-    return check_lib(
+    use Mock::Config ccflags => clean_ccflags();
+    my $ret = check_lib(
         debug => 0,
         function => 'sodium_init(); return crypto_stream_aes128ctr_NONCEBYTES ? 0 : 1;',
-        LIBS => Alien::Sodium->libs,
-        ccflags => Alien::Sodium->cflags(),
+        LIBS => $alien_libs,
+        ccflags => $alien_cflags,
         header => 'sodium.h',
     );
+    Mock::Config->unimport;      # Undo overrides
+    return $ret;
 }
 
 my @defines;
@@ -36,6 +55,10 @@ push @defines, 'AES128CTR_IS_AVAILABLE' if has_aes128ctr();
 my %xsbuild = Alien::Base::Wrapper->new('Alien::Sodium')->mm_args2(
     "DEFINE" => join(" ", map { "-D$_" } @defines),
 );
+$xsbuild{"LIBS"}    = [ $alien_libs ];
+$xsbuild{"CCFLAGS"} = $alien_cflags;
+$xsbuild{"INC"}     = $alien_include;
+
 # use Data::Dumper;
 # print Dumper(\%xsbuild);
 # exit(1);


### PR DESCRIPTION
    Fix issue where the incorrect version of the library
    or headers could be found either by the Devel::CheckLib
    or by the Module itself.
    
    Devel::CheckLib uses $Config{ccflags} which has the -I from Perl
    which is not wanted when attempting to Compile the test check_lib
    function against libsodium.  Since /usr/local/include was first on
    the command line the non-alien header files were found.
    https://rt.cpan.org/Ticket/Display.html?id=173214
    
    In addition we need to set the MakeMaker INC and LIBS explicitly
    to ensure the Alien version is used.
    
    Being explicit will also be needed for the option to use a non-Alien
    version of the Library
